### PR TITLE
fix(package.json): add activation event for jira-to-code.ai command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
         "Other"
     ],
     "main": "./out/extension.js",
-    "activationEvents": [],
+   	"activationEvents": [
+  		"onCommand:jira-to-code.ai"
+	],
+
     "contributes": {
         "commands": [
             {


### PR DESCRIPTION
### Changes
- Added activation event so the extension activates when running the jira-to-code.ai command.

### Why
- Without this, the extension would not activate when the command was used from Command Palette.

### Impact
- Ensures the "Jira to Code AI" command works as expected.
