### PR TITLE
chore(eslint): add rules for unused vars, promises, and import order

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,14 +15,24 @@ export default [{
     },
 
     rules: {
-        "@typescript-eslint/naming-convention": ["warn", {
-            selector: "import",
-            format: ["camelCase", "PascalCase"],
-        }],
+    "@typescript-eslint/naming-convention": ["warn", {
+        selector: "import",
+        format: ["camelCase", "PascalCase"],
+    }],
 
-        curly: "warn",
-        eqeqeq: "warn",
-        "no-throw-literal": "warn",
-        semi: "warn",
-    },
+    curly: "warn",
+    eqeqeq: "warn",
+    "no-throw-literal": "warn",
+    semi: "warn",
+
+    // 🔥 new rules
+    "no-unused-vars": "warn",
+    "no-console": "warn",
+    "@typescript-eslint/no-floating-promises": "error",
+    "import/order": ["warn", {
+        "groups": ["builtin", "external", "internal"],
+        "alphabetize": { "order": "asc", "caseInsensitive": true }
+    }]
+}
+
 }];

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
         "Other"
     ],
     "main": "./out/extension.js",
-    "activationEvents": [],
+   	"activationEvents": [
+  		"onCommand:jira-to-code.ai"
+	],
+
     "contributes": {
         "commands": [
             {


### PR DESCRIPTION
### Summary
- Added stricter ESLint rules to improve code quality and consistency.

### Changes
- Warn on unused variables (`no-unused-vars`)
- Warn on accidental `console.log` in code
- Enforce handling of promises (`@typescript-eslint/no-floating-promises`)
- Enforce consistent import order (`import/order`)

### Why
Helps keep the codebase clean, prevents missed promise errors, and ensures imports stay organized.
